### PR TITLE
feat: add global dark/light theme toggle with persistence

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -6,7 +6,10 @@
 
 ## Customizing Components
 
-<!-- How to customize or create new components will be documented as the project evolves. -->
+- The global dark/light theme toggle is implemented in `src/app/components/ThemeToggle.tsx`.
+- It uses Tailwind's dark class strategy and persists the user's preference in localStorage.
+- The toggle is accessible from the header (see `src/app/layout.tsx`).
+- To customize the toggle, edit the `ThemeToggle` component or its placement in the layout.
 
 ## Extending Features
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A modern portfolio website built with Next.js, TypeScript, and TailwindCSS. This
 
 - Modern, responsive design
 - Easy to customize and extend
+- Global dark/light theme toggle with persistence
 - Code quality enforced with ESLint, Prettier, Husky, and lint-staged
 
 ## Installation

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+const THEME_KEY = 'theme';
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem(THEME_KEY) as 'light' | 'dark') || 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <button
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      onClick={toggleTheme}
+      className="p-2 rounded focus:outline-none focus:ring transition-colors bg-muted hover:bg-accent"
+    >
+      {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
+    </button>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,21 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from 'next';
+import { Geist, Geist_Mono } from 'next/font/google';
+import './globals.css';
+import { ThemeToggle } from './components/ThemeToggle';
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
-  title: "My Portfolio",
-  description: "A boilerplate for building a portfolio website",
+  title: 'My Portfolio',
+  description: 'A boilerplate for building a portfolio website',
 };
 
 export default function RootLayout({
@@ -24,9 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <header className="w-full flex justify-end p-4">
+          <ThemeToggle />
+        </header>
         {children}
       </body>
     </html>


### PR DESCRIPTION
- Implemented a global dark/light theme toggle using Tailwind's dark class strategy.
- User's theme preference is persisted in localStorage and applied across sessions.
- The toggle is accessible from the header and works throughout the entire application.
- Added `ThemeToggle` component in `src/app/components/ThemeToggle.tsx` and integrated it into the layout.
- Updated README.md with new feature and usage instructions.
- Updated GUIDE.md with details on theme toggle implementation and customization.