### PR TITLE
feat: add modular typed content layer in /data for dynamic portfolio sections

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,37 @@
 
 ## Editing Content in `/data`
 
-<!-- Instructions for editing content in the /data directory will be added as features are implemented. -->
+All dynamic content is managed in the `/data` folder. Each file is typed and modular, making it easy to update or extend content for the portfolio.
+
+### Files
+
+- `projects.ts`: Project data and types
+- `journey.ts`: Professional journey data and types
+- `skills.ts`: Skills data and types
+- `socials.ts`: Social/contact data and types
+- `personalJourney.ts`: Personal (non-professional) experiences and types
+- `home.ts`: Home page metadata
+
+### How to Add or Edit Content
+
+- To add a new project, edit `projects.ts` and add a new object to the `projects` array.
+- To add a new professional experience, edit `journey.ts` and add a new object to the `journey` array.
+- To add a new skill, edit `skills.ts` and add a new object to the `skills` array.
+- To add a new social link, edit `socials.ts` and add a new object to the `socials` array.
+- To add a new personal experience, edit `personalJourney.ts` and add a new object to the `personalJourney` array.
+
+Each file also exports a section title and subtitle for use in the UI.
+
+### Best Practices
+
+- Keep all content in English.
+- Use realistic but generic placeholders for demo data.
+- Update types if you need to extend the data structure.
+- Use the exported titles/subtitles for consistent UI sections.
+
+---
+
+For more information, see the README.md file.
 
 ## Customizing Components
 

--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ When you try to commit, Husky will run:
 - Type checking with `tsc --noEmit`
 
 If any of these steps fail, the commit will be blocked until the code is compliant.
+
+## Customization
+
+All content is managed in the `/data` folder. For technical details and how to extend the data structure, see [GUIDE.md](./GUIDE.md).
+
+---
+
+Feel free to fork, customize, and make it your own!

--- a/data/home.ts
+++ b/data/home.ts
@@ -1,0 +1,13 @@
+export const homeTitle = 'Welcome to the Portfolio';
+export const homeSubtitle =
+  'Explore projects, experiences, and lessons in a dynamic and organized way.';
+export const homeDescription =
+  'This portfolio provides a complete overview of projects, skills, professional and personal journeys, as well as ways to get in touch.';
+export const homeKeywords = [
+  'portfolio',
+  'projects',
+  'career',
+  'skills',
+  'personal experiences',
+  'contact',
+];

--- a/data/journey.ts
+++ b/data/journey.ts
@@ -1,0 +1,39 @@
+export const journeyTitle = 'Professional Journey';
+export const journeySubtitle =
+  'Professional experiences, roles, and main achievements throughout the career.';
+
+export type JourneyEntry = {
+  slug: string;
+  title: string;
+  company: string;
+  period: string;
+  description: string;
+  highlights: string[];
+};
+
+export const journey: JourneyEntry[] = [
+  {
+    slug: 'frontend-lead',
+    title: 'Front-End Lead',
+    company: 'TechNova Solutions',
+    period: 'Jan 2024 – Present',
+    description: 'Leading a team to build scalable web applications for enterprise clients.',
+    highlights: [
+      'Architected a design system used across multiple products',
+      'Mentored junior developers in React and TypeScript',
+      'Improved performance of legacy apps by 40%',
+    ],
+  },
+  {
+    slug: 'backend-engineer',
+    title: 'Backend Engineer',
+    company: 'CloudSync Inc.',
+    period: 'Aug 2021 – Dec 2023',
+    description: 'Developed APIs and microservices for cloud-based file storage solutions.',
+    highlights: [
+      'Implemented authentication and authorization modules',
+      'Optimized database queries for large-scale data',
+      'Collaborated with DevOps to automate deployments',
+    ],
+  },
+];

--- a/data/personalJourney.ts
+++ b/data/personalJourney.ts
@@ -1,0 +1,40 @@
+export const personalJourneyTitle = 'Personal Journey';
+export const personalJourneySubtitle =
+  'Stories, challenges, and lessons learned outside the professional environment.';
+
+export type PersonalEntry = {
+  slug: string;
+  title: string;
+  date: string;
+  image?: string;
+  description: string;
+  reflections: string[];
+  tags: string[];
+};
+
+export const personalJourney: PersonalEntry[] = [
+  {
+    slug: 'marathon-challenge',
+    title: 'Completing My First Marathon',
+    date: '2022-10-15',
+    image: '/images/personal/marathon.png',
+    description:
+      'A journey of discipline and perseverance to finish a full marathon after months of training.',
+    reflections: [
+      'Consistency beats motivation.',
+      'Small daily efforts lead to big achievements.',
+      'Physical challenges build mental strength.',
+    ],
+    tags: ['Discipline', 'Endurance', 'Routine'],
+  },
+  {
+    slug: 'digital-detox-week',
+    title: 'A Week Without Social Media',
+    date: '2023-03-05',
+    image: '/images/personal/detox.png',
+    description:
+      'Taking a break from digital distractions to reconnect with offline activities and mindfulness.',
+    reflections: ['Mindful breaks improve focus.', 'Offline time enhances creativity.'],
+    tags: ['Wellness', 'Routine', 'Mindfulness'],
+  },
+];

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -1,0 +1,43 @@
+export const projectsTitle = 'Projects';
+export const projectsSubtitle =
+  'A selection of public and private projects, built with different stacks and purposes.';
+
+export type Project = {
+  slug: string;
+  title: string;
+  description: string;
+  stack: string[];
+  demoUrl?: string;
+  repoUrl?: string;
+  repoPrivate?: boolean;
+  featured?: boolean;
+  tags?: string[];
+  date: string;
+  thumbnail?: string;
+};
+
+export const projects: Project[] = [
+  {
+    slug: 'taskmaster-pro',
+    title: 'TaskMaster Pro',
+    description: 'A productivity app for managing daily tasks and projects collaboratively.',
+    stack: ['Next.js', 'TypeScript', 'MongoDB', 'Tailwind CSS'],
+    demoUrl: 'https://taskmasterpro.app',
+    repoUrl: 'https://github.com/example/taskmaster-pro',
+    repoPrivate: false,
+    featured: true,
+    tags: ['Productivity', 'Collaboration', 'App'],
+    date: '2024-05-10',
+    thumbnail: '/images/projects/taskmaster-thumb.png',
+  },
+  {
+    slug: 'weatherly',
+    title: 'Weatherly',
+    description: 'A weather dashboard providing real-time forecasts and climate analytics.',
+    stack: ['React', 'Node.js', 'Express', 'PostgreSQL'],
+    repoPrivate: true,
+    featured: false,
+    tags: ['Weather', 'Dashboard'],
+    date: '2023-09-15',
+  },
+];

--- a/data/skills.ts
+++ b/data/skills.ts
@@ -1,0 +1,17 @@
+export const skillsTitle = 'Skills';
+export const skillsSubtitle = 'Main technologies, frameworks, and technical competencies.';
+
+export type Skill = {
+  name: string;
+  level?: 'beginner' | 'intermediate' | 'advanced';
+  category?: string;
+};
+
+export const skills: Skill[] = [
+  { name: 'Vue.js', level: 'advanced', category: 'Frontend' },
+  { name: 'Angular', level: 'intermediate', category: 'Frontend' },
+  { name: 'Python', level: 'advanced', category: 'Language' },
+  { name: 'Django', level: 'intermediate', category: 'Backend' },
+  { name: 'MySQL', level: 'intermediate', category: 'Database' },
+  { name: 'Sass', level: 'advanced', category: 'Styling' },
+];

--- a/data/socials.ts
+++ b/data/socials.ts
@@ -1,0 +1,31 @@
+export const socialsTitle = 'Social & Contact';
+export const socialsSubtitle = 'Where you can find or contact me.';
+
+export type Social = {
+  platform: string;
+  url: string;
+  icon?: string;
+};
+
+export const socials: Social[] = [
+  {
+    platform: 'GitHub',
+    url: 'https://github.com/exampleuser',
+    icon: 'github',
+  },
+  {
+    platform: 'LinkedIn',
+    url: 'https://linkedin.com/in/exampleuser',
+    icon: 'linkedin',
+  },
+  {
+    platform: 'Twitter',
+    url: 'https://twitter.com/exampleuser',
+    icon: 'twitter',
+  },
+  {
+    platform: 'Email',
+    url: 'mailto:contact@example.com',
+    icon: 'mail',
+  },
+];


### PR DESCRIPTION
## What’s new

- Introduced a fully modular and typed content layer in the `/data` folder for dynamic portfolio content.
- Added the following files and types:
  - `projects.ts`: Project data and types (with support for private repos)
  - `journey.ts`: Professional journey entries and types
  - `skills.ts`: Skills and types
  - `socials.ts`: Social/contact links and types
  - `personalJourney.ts`: Personal (non-professional) experiences and types
  - `home.ts`: Home page metadata

## Details

- Each file exports its own type, data array, and section titles/subtitles for use in the main screens.
- All placeholder data is generic and in English.
- Documentation in `README.md` and `GUIDE.md` was updated to reflect the new structure.
