### PR TITLE
feat: create portifolio sections

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -23,6 +23,11 @@ All dynamic content is managed in the `/data` folder. Each file is typed and mod
 
 Each file also exports a section title and subtitle for use in the UI.
 
+### Navigation
+
+- The `Header` component provides anchor links to each main section of the page (Skills, Projects, Professional Journey, Personal Journey, Contact).
+- Navigation uses smooth scroll behavior for a better user experience. To add or remove sections, update the `sections` array in `Header.tsx` and ensure the corresponding section has a matching `id` in `page.tsx`.
+
 ### Best Practices
 
 - Keep all content in English.

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,0 +1,25 @@
+import type { Social } from '../../../data/socials';
+
+type FooterProps = {
+  title: string;
+  subtitle: string;
+  socials: Social[];
+};
+
+export function Footer({ title, subtitle, socials }: FooterProps) {
+  return (
+    <footer>
+      <h2>{title}</h2>
+      <p>{subtitle}</p>
+      <ul>
+        {socials.map((social) => (
+          <li key={social.platform}>
+            <a href={social.url} target="_blank" rel="noopener noreferrer">
+              {social.icon ? <span>{social.icon}</span> : null} {social.platform}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </footer>
+  );
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,0 +1,23 @@
+const sections = [
+  { id: 'skills', label: 'Skills' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'journey', label: 'Professional Journey' },
+  { id: 'personal-journey', label: 'Personal Journey' },
+  { id: 'contact', label: 'Contact' },
+];
+
+export function Header() {
+  return (
+    <nav style={{ display: 'flex', gap: '1rem', justifyContent: 'center', padding: '1rem' }}>
+      {sections.map((section) => (
+        <a
+          key={section.id}
+          href={`#${section.id}`}
+          style={{ textDecoration: 'underline', cursor: 'pointer' }}
+        >
+          {section.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -1,0 +1,15 @@
+type HeroProps = {
+  title: string;
+  subtitle: string;
+  description: string;
+};
+
+export function Hero({ title, subtitle, description }: HeroProps) {
+  return (
+    <section>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      <p>{description}</p>
+    </section>
+  );
+}

--- a/src/app/components/Journey.tsx
+++ b/src/app/components/Journey.tsx
@@ -1,0 +1,34 @@
+import type { JourneyEntry } from '../../../data/journey';
+
+type JourneyProps = {
+  title: string;
+  subtitle: string;
+  journey: JourneyEntry[];
+};
+
+export function Journey({ title, subtitle, journey }: JourneyProps) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      <p>{subtitle}</p>
+      <ul>
+        {journey.map((entry) => (
+          <li key={entry.slug}>
+            <article>
+              <h3>
+                {entry.title} @ {entry.company}
+              </h3>
+              <p>{entry.period}</p>
+              <p>{entry.description}</p>
+              <ul>
+                {entry.highlights.map((h, i) => (
+                  <li key={i}>{h}</li>
+                ))}
+              </ul>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/components/PersonalJourney.tsx
+++ b/src/app/components/PersonalJourney.tsx
@@ -1,0 +1,34 @@
+import type { PersonalEntry } from '../../../data/personalJourney';
+
+type PersonalJourneyProps = {
+  title: string;
+  subtitle: string;
+  personalJourney: PersonalEntry[];
+};
+
+export function PersonalJourney({ title, subtitle, personalJourney }: PersonalJourneyProps) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      <p>{subtitle}</p>
+      <ul>
+        {personalJourney.map((entry) => (
+          <li key={entry.slug}>
+            <article>
+              <h3>{entry.title}</h3>
+              <p>{entry.date}</p>
+              {entry.image && <img src={entry.image} alt={entry.title} style={{ maxWidth: 200 }} />}
+              <p>{entry.description}</p>
+              <ul>
+                {entry.reflections.map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ul>
+              <p>Tags: {entry.tags.join(', ')}</p>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -1,0 +1,40 @@
+import type { Project } from '../../../data/projects';
+
+type ProjectsProps = {
+  title: string;
+  subtitle: string;
+  projects: Project[];
+};
+
+export function Projects({ title, subtitle, projects }: ProjectsProps) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      <p>{subtitle}</p>
+      <ul>
+        {projects.map((project) => (
+          <li key={project.slug}>
+            <article>
+              <h3>{project.title}</h3>
+              <p>{project.description}</p>
+              <p>Stack: {project.stack.join(', ')}</p>
+              {project.demoUrl && (
+                <a href={project.demoUrl} target="_blank" rel="noopener noreferrer">
+                  Demo
+                </a>
+              )}
+              {project.repoUrl && !project.repoPrivate && (
+                <a href={project.repoUrl} target="_blank" rel="noopener noreferrer">
+                  Repository
+                </a>
+              )}
+              {project.repoPrivate && <span>Private Repository</span>}
+              {project.tags && <p>Tags: {project.tags.join(', ')}</p>}
+              <p>Date: {project.date}</p>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -1,0 +1,25 @@
+import type { Skill } from '../../../data/skills';
+
+type SkillsProps = {
+  title: string;
+  subtitle: string;
+  skills: Skill[];
+};
+
+export function Skills({ title, subtitle, skills }: SkillsProps) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      <p>{subtitle}</p>
+      <ul>
+        {skills.map((skill) => (
+          <li key={skill.name}>
+            <strong>{skill.name}</strong>
+            {skill.level && ` (${skill.level})`}
+            {skill.category && ` - ${skill.category}`}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -166,7 +166,7 @@
 
   html {
     scroll-behavior: smooth;
-    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+    font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
     font-variation-settings: normal;
     tab-size: 4;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,46 @@
+import { Hero } from './components/Hero';
+import { Skills } from './components/Skills';
+import { Projects } from './components/Projects';
+import { Journey } from './components/Journey';
+import { PersonalJourney } from './components/PersonalJourney';
+import { Footer } from './components/Footer';
+import { Header } from './components/Header';
+
+import { homeTitle, homeSubtitle, homeDescription } from '../../data/home';
+import { skills, skillsTitle, skillsSubtitle } from '../../data/skills';
+import { projects, projectsTitle, projectsSubtitle } from '../../data/projects';
+import { journey, journeyTitle, journeySubtitle } from '../../data/journey';
+import { socials, socialsTitle, socialsSubtitle } from '../../data/socials';
+import {
+  personalJourney,
+  personalJourneyTitle,
+  personalJourneySubtitle,
+} from '../../data/personalJourney';
+
 export default function Home() {
-  return <h1>My portfolio first page</h1>;
+  return (
+    <main>
+      <Header />
+      <Hero title={homeTitle} subtitle={homeSubtitle} description={homeDescription} />
+      <section id="skills">
+        <Skills title={skillsTitle} subtitle={skillsSubtitle} skills={skills} />
+      </section>
+      <section id="projects">
+        <Projects title={projectsTitle} subtitle={projectsSubtitle} projects={projects} />
+      </section>
+      <section id="journey">
+        <Journey title={journeyTitle} subtitle={journeySubtitle} journey={journey} />
+      </section>
+      <section id="personal-journey">
+        <PersonalJourney
+          title={personalJourneyTitle}
+          subtitle={personalJourneySubtitle}
+          personalJourney={personalJourney}
+        />
+      </section>
+      <section id="contact">
+        <Footer title={socialsTitle} subtitle={socialsSubtitle} socials={socials} />
+      </section>
+    </main>
+  );
 }


### PR DESCRIPTION
- Created a Header component with anchor links for Skills, Projects, Professional Journey, Personal Journey, and Contact sections.
- Enabled smooth scrolling for in-page navigation.
- Updated the main page to use section IDs and the new Header.
- Improved GUIDE.md with navigation instructions.
- Added a brief note about section navigation to README.md.