### PR TITLE
feat: add dynamic project details pages and expand project model

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,12 +1,12 @@
 # Developer & User Guide
 
-## Editing Content in `/data`
+## Modular Data Layer
 
 All dynamic content is managed in the `/data` folder. Each file is typed and modular, making it easy to update or extend content for the portfolio.
 
 ### Files
 
-- `projects.ts`: Project data and types
+- `projects.ts`: Project data and types (now includes motivation, challenges, learnings, details)
 - `journey.ts`: Professional journey data and types
 - `skills.ts`: Skills data and types
 - `socials.ts`: Social/contact data and types
@@ -15,7 +15,7 @@ All dynamic content is managed in the `/data` folder. Each file is typed and mod
 
 ### How to Add or Edit Content
 
-- To add a new project, edit `projects.ts` and add a new object to the `projects` array.
+- To add a new project, edit `projects.ts` and add a new object to the `projects` array. You can now include fields like `motivation`, `challenges`, `learnings`, and `details` for richer project pages.
 - To add a new professional experience, edit `journey.ts` and add a new object to the `journey` array.
 - To add a new skill, edit `skills.ts` and add a new object to the `skills` array.
 - To add a new social link, edit `socials.ts` and add a new object to the `socials` array.
@@ -27,6 +27,12 @@ Each file also exports a section title and subtitle for use in the UI.
 
 - The `Header` component provides anchor links to each main section of the page (Skills, Projects, Professional Journey, Personal Journey, Contact).
 - Navigation uses smooth scroll behavior for a better user experience. To add or remove sections, update the `sections` array in `Header.tsx` and ensure the corresponding section has a matching `id` in `page.tsx`.
+
+### Project Details Pages
+
+- Each project has a dynamic page at `/projects/[slug]` that displays all available details, including the new fields.
+- If `repoPrivate` is true, the repository link is replaced with a "Private Repository" label.
+- To link to a project details page, use `<Link href={/projects/${project.slug}}>`.
 
 ### Best Practices
 

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -14,6 +14,10 @@ export type Project = {
   tags?: string[];
   date: string;
   thumbnail?: string;
+  motivation?: string;
+  challenges?: string[];
+  learnings?: string[];
+  details?: string;
 };
 
 export const projects: Project[] = [
@@ -29,6 +33,17 @@ export const projects: Project[] = [
     tags: ['Productivity', 'Collaboration', 'App'],
     date: '2024-05-10',
     thumbnail: '/images/projects/taskmaster-thumb.png',
+    motivation: 'To help teams and individuals organize their work and boost productivity.',
+    challenges: [
+      'Designing a real-time collaborative editing experience',
+      'Ensuring data consistency across devices',
+    ],
+    learnings: [
+      'Deepened knowledge of WebSockets and real-time data flows',
+      'Improved UI/UX for productivity tools',
+    ],
+    details:
+      'TaskMaster Pro allows users to create, assign, and track tasks in real time, with advanced filtering and analytics.',
   },
   {
     slug: 'weatherly',
@@ -39,5 +54,14 @@ export const projects: Project[] = [
     featured: false,
     tags: ['Weather', 'Dashboard'],
     date: '2023-09-15',
+    thumbnail: '/images/projects/weatherly-thumb.png',
+    motivation: 'To make weather data more accessible and actionable for everyday users.',
+    challenges: [
+      'Integrating multiple third-party weather APIs',
+      'Handling inconsistent data formats',
+    ],
+    learnings: ['API normalization strategies', 'Building robust error handling for external data'],
+    details:
+      'Weatherly aggregates weather data from several sources, providing users with accurate forecasts and climate trends.',
   },
 ];

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -1,4 +1,5 @@
 import type { Project } from '../../../data/projects';
+import Link from 'next/link';
 
 type ProjectsProps = {
   title: string;
@@ -19,9 +20,12 @@ export function Projects({ title, subtitle, projects }: ProjectsProps) {
               <p>{project.description}</p>
               <p>Stack: {project.stack.join(', ')}</p>
               {project.demoUrl && (
-                <a href={project.demoUrl} target="_blank" rel="noopener noreferrer">
-                  Demo
-                </a>
+                <>
+                  <a href={project.demoUrl} target="_blank" rel="noopener noreferrer">
+                    Demo
+                  </a>
+                  {' | '}
+                </>
               )}
               {project.repoUrl && !project.repoPrivate && (
                 <a href={project.repoUrl} target="_blank" rel="noopener noreferrer">
@@ -29,6 +33,13 @@ export function Projects({ title, subtitle, projects }: ProjectsProps) {
                 </a>
               )}
               {project.repoPrivate && <span>Private Repository</span>}
+              {' | '}
+              <Link href={`/projects/${project.slug}`}>More details</Link>
+              {project.details && (
+                <p>
+                  <em>{project.details}</em>
+                </p>
+              )}
               {project.tags && <p>Tags: {project.tags.join(', ')}</p>}
               <p>Date: {project.date}</p>
             </article>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { projects } from '../../../../data/projects';
+import Image from 'next/image';
+
+type ProjectPageProps = {
+  params: { slug: string };
+};
+
+export default function ProjectPage({ params }: ProjectPageProps) {
+  const project = projects.find((p) => p.slug === params.slug);
+  if (!project) return notFound();
+
+  return (
+    <main style={{ maxWidth: 700, margin: '0 auto', padding: 24 }}>
+      <nav style={{ marginBottom: 24 }}>
+        <Link href="/">← Back to Home</Link>
+      </nav>
+      <h1>{project.title}</h1>
+      <p>{project.description}</p>
+      {project.thumbnail && (
+        <Image
+          src={project.thumbnail}
+          alt={project.title}
+          width={600}
+          height={340}
+          style={{ borderRadius: 8 }}
+        />
+      )}
+      <section>
+        <h2>Stack</h2>
+        <ul>
+          {project.stack.map((tech) => (
+            <li key={tech}>{tech}</li>
+          ))}
+        </ul>
+        {project.tags && (
+          <p>
+            <strong>Tags:</strong> {project.tags.join(', ')}
+          </p>
+        )}
+        <p>
+          <strong>Date:</strong> {project.date}
+        </p>
+      </section>
+      {project.details && (
+        <section>
+          <h2>Details</h2>
+          <p>{project.details}</p>
+        </section>
+      )}
+      {project.motivation && (
+        <section>
+          <h2>Motivation</h2>
+          <p>{project.motivation}</p>
+        </section>
+      )}
+      {project.challenges && project.challenges.length > 0 && (
+        <section>
+          <h2>Challenges</h2>
+          <ul>
+            {project.challenges.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {project.learnings && project.learnings.length > 0 && (
+        <section>
+          <h2>Learnings</h2>
+          <ul>
+            {project.learnings.map((l, i) => (
+              <li key={i}>{l}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <section style={{ marginTop: 24 }}>
+        {project.demoUrl && (
+          <a
+            href={project.demoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ marginRight: 16 }}
+          >
+            Live Demo
+          </a>
+        )}
+        {project.repoUrl && !project.repoPrivate && (
+          <a href={project.repoUrl} target="_blank" rel="noopener noreferrer">
+            Repository
+          </a>
+        )}
+        {project.repoPrivate && (
+          <span style={{ color: 'red', marginLeft: 8 }}>Private Repository</span>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
### What’s new

- Added new fields to the Project model: motivation, challenges, learnings, and details.
- Created dynamic route `/projects/[slug]` to display full project details.
- Each project in the list now links to its own details page.
- Project details page shows all available information, including stack, tags, thumbnail, motivation, challenges, learnings, and more.
- If `repoPrivate` is true, the repository link is replaced with a "Private Repository" label.
- Added a "Back to Home" link at the top of the project details page for easy navigation.
- Updated documentation (GUIDE.md) to reflect these changes.
