### PR TITLE
feat: add dynamic detail pages for journey and personalJourney

### DIFF
--- a/src/app/components/Journey.tsx
+++ b/src/app/components/Journey.tsx
@@ -1,4 +1,5 @@
 import type { JourneyEntry } from '../../../data/journey';
+import Link from 'next/link';
 
 type JourneyProps = {
   title: string;
@@ -16,7 +17,9 @@ export function Journey({ title, subtitle, journey }: JourneyProps) {
           <li key={entry.slug}>
             <article>
               <h3>
-                {entry.title} @ {entry.company}
+                <Link href={`/journey/${entry.slug}`}>
+                  {entry.title} @ {entry.company}
+                </Link>
               </h3>
               <p>{entry.period}</p>
               <p>{entry.description}</p>

--- a/src/app/components/PersonalJourney.tsx
+++ b/src/app/components/PersonalJourney.tsx
@@ -1,4 +1,6 @@
 import type { PersonalEntry } from '../../../data/personalJourney';
+import Link from 'next/link';
+import Image from 'next/image';
 
 type PersonalJourneyProps = {
   title: string;
@@ -15,9 +17,19 @@ export function PersonalJourney({ title, subtitle, personalJourney }: PersonalJo
         {personalJourney.map((entry) => (
           <li key={entry.slug}>
             <article>
-              <h3>{entry.title}</h3>
+              <h3>
+                <Link href={`/journey/${entry.slug}`}>{entry.title}</Link>
+              </h3>
               <p>{entry.date}</p>
-              {entry.image && <img src={entry.image} alt={entry.title} style={{ maxWidth: 200 }} />}
+              {entry.image && (
+                <Image
+                  src={entry.image}
+                  alt={entry.title}
+                  width={200}
+                  height={120}
+                  style={{ maxWidth: 200 }}
+                />
+              )}
               <p>{entry.description}</p>
               <ul>
                 {entry.reflections.map((r, i) => (

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -21,27 +21,21 @@ export function Projects({ title, subtitle, projects }: ProjectsProps) {
           return (
             <li key={project.slug}>
               <article>
-                <h3>{project.title}</h3>
+                <h3>
+                  <Link href={`/projects/${project.slug}`}>{project.title}</Link>
+                </h3>
                 <p>{project.description}</p>
                 {project.demoUrl && (
                   <a href={project.demoUrl} target="_blank" rel="noopener noreferrer">
                     Demo
                   </a>
                 )}
-                {' | '}
                 {project.repoUrl && !project.repoPrivate && (
                   <a href={project.repoUrl} target="_blank" rel="noopener noreferrer">
                     Repository
                   </a>
                 )}
                 {project.repoPrivate && <span>Private Repository</span>}
-                {' | '}
-                <Link href={`/projects/${project.slug}`}>More details</Link>
-                {project.details && (
-                  <p>
-                    <em>{project.details}</em>
-                  </p>
-                )}
                 {techTags.length > 0 && (
                   <div className="flex flex-wrap mt-2">
                     <span className="mr-2 font-semibold text-sm">Tech Stack:</span>

--- a/src/app/journey/[slug]/page.tsx
+++ b/src/app/journey/[slug]/page.tsx
@@ -1,0 +1,81 @@
+import { journey } from '../../../../data/journey';
+import { personalJourney } from '../../../../data/personalJourney';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function JourneyDetailPage({ params }: { params: { slug: string } }) {
+  const entry = journey.find((j) => j.slug === params.slug);
+  const personal = personalJourney.find((p) => p.slug === params.slug);
+
+  if (!entry && !personal) {
+    return (
+      <main style={{ maxWidth: 700, margin: '0 auto', padding: 24 }}>
+        <nav style={{ marginBottom: 24 }}>
+          <Link href="/">← Back to Home</Link>
+        </nav>
+        <h1>Page not found</h1>
+        <p>The requested role or experience was not found.</p>
+      </main>
+    );
+  }
+
+  if (entry) {
+    return (
+      <main style={{ maxWidth: 700, margin: '0 auto', padding: 24 }}>
+        <nav style={{ marginBottom: 24 }}>
+          <Link href="/">← Back to Home</Link>
+        </nav>
+        <h1>
+          {entry.title} @ {entry.company}
+        </h1>
+        <p>
+          <strong>Period:</strong> {entry.period}
+        </p>
+        <p>{entry.description}</p>
+        <section>
+          <h2>Highlights</h2>
+          <ul>
+            {entry.highlights.map((h, i) => (
+              <li key={i}>{h}</li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    );
+  }
+
+  // Personal Journey
+  if (!personal) return null;
+  return (
+    <main style={{ maxWidth: 700, margin: '0 auto', padding: 24 }}>
+      <nav style={{ marginBottom: 24 }}>
+        <Link href="/">← Back to Home</Link>
+      </nav>
+      <h1>{personal.title}</h1>
+      <p>
+        <strong>Date:</strong> {personal.date}
+      </p>
+      {personal.image && (
+        <Image
+          src={personal.image}
+          alt={personal.title}
+          width={400}
+          height={250}
+          style={{ maxWidth: 400, borderRadius: 8, height: 'auto' }}
+        />
+      )}
+      <p>{personal.description}</p>
+      <section>
+        <h2>Reflections</h2>
+        <ul>
+          {personal.reflections.map((r, i) => (
+            <li key={i}>{r}</li>
+          ))}
+        </ul>
+      </section>
+      <p>
+        <strong>Tags:</strong> {personal.tags.join(', ')}
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## What's new

- Added dynamic detail pages for both professional journey and personal journey entries, accessible via slug-based routes.
- Implemented fallback handling for invalid or missing slugs.
- Updated project list: project titles are now clickable links to their detail pages (removed the separate "More details" link).
- Ensured all UI text and labels are in English, following project guidelines.
- Improved consistency in navigation between projects and journey sections.